### PR TITLE
fix: handle reads with len > 0

### DIFF
--- a/packet_reader.go
+++ b/packet_reader.go
@@ -50,7 +50,7 @@ func (s *rtuPacketReader) Read(p []byte) (int, error) {
 			// time.Sleep(time.Duration(rand.Int63n(int64(time.Second / 10))))
 			n, err := s.r.Read(p[read:])
 			now := time.Now()
-			if read != 0 {
+			if read > 0 {
 				cutoffDuration := GetPacketCutoffDurationFromSerialContext(s.r, n)
 				readDuration := now.Sub(s.lastReadAt)
 				if readDuration > cutoffDuration {


### PR DESCRIPTION
Read should not return negative values, but theare are some serial libraries that do return -1 in case of error against the specification.

In case of Read returns -1 currently p[read:read+n] panics.  If we check read > 0 instead of read != 0 this would not be a problem.
