### PR TITLE
bug-fix: do not trust large packet size headers

### DIFF
--- a/packet_reader.go
+++ b/packet_reader.go
@@ -75,13 +75,14 @@ func (s *rtuPacketReader) Read(p []byte) (int, error) {
 		// lets see if there is more to read
 		if s.bidirectional {
 			expected = GetRTUBidirectionalSizeFromHeader(p[:read])
-			debugf("RTUPacketReader new expected size %v %x", expected, p[:read])
+			debugf("GetRTUBidirectionalSizeFromHeader new expected size %v %x", expected, p[:read])
 		} else {
 			expected = GetRTUSizeFromHeader(p[:read], s.isClient)
-			debugf("RTUPacketReader new expected size %v %v %x", expected, s.isClient, p[:read])
+			debugf("GetRTUSizeFromHeader new expected size %v %v %x", expected, s.isClient, p[:read])
 		}
 		if expected > read-1 {
-			time.Sleep(s.r.BytesDelay(expected - read))
+			waitForBytes := min(8, expected - read)
+			time.Sleep(s.r.BytesDelay(waitForBytes))
 		}
 	}
 	if read > expected {
@@ -127,10 +128,13 @@ func GetPDUSizeFromHeader(header []byte, isClient bool) int {
 	}
 	if OverSizeSupport {
 		n := int(header[3])*256 + int(header[4])
+		var overSize int
 		if f.IsUint16() {
-			return 6 + n*2
+			overSize = 6 + n*2
+		}else{
+			overSize = 6 + (n-1)/8 + 1
 		}
-		return 6 + (n-1)/8 + 1
+		return min(GetMaxPDUSize(), overSize)
 	}
 	return 6 + int(header[5])
 }

--- a/serial_rtu.go
+++ b/serial_rtu.go
@@ -13,17 +13,18 @@ const MaxRTUSize = 256
 const MaxPDUSize = 253
 
 // OverSizeSupport ignores max packet size and encoded number of bytes to support
-// over sided implementations encountered in the wild. This setting only applies
+// over sized implementations encountered in the wild. This setting only applies
 // to the server end, since client is always reserved in what it requests.
 // Also change OverSizeMaxRTU properly.
 var OverSizeSupport = false
 
 // OverSizeMaxRTU overrides MaxRTUSize when OverSizeSupport is true.
+// It should not be smaller than MaxRTUSize.
 var OverSizeMaxRTU = MaxRTUSize
 
 func GetMaxPDUSize() int {
 	if OverSizeSupport{
-		return OverSizeMaxRTU - 3
+		return max(MaxPDUSize, OverSizeMaxRTU - 3)
 	}
 	return MaxPDUSize
 }

--- a/serial_rtu.go
+++ b/serial_rtu.go
@@ -21,6 +21,13 @@ var OverSizeSupport = false
 // OverSizeMaxRTU overrides MaxRTUSize when OverSizeSupport is true.
 var OverSizeMaxRTU = MaxRTUSize
 
+func GetMaxPDUSize() int {
+	if OverSizeSupport{
+		return OverSizeMaxRTU - 3
+	}
+	return MaxPDUSize
+}
+
 const smallestRTUSize = 4
 
 // RTU is the Modbus RTU Application Data Unit.


### PR DESCRIPTION
When oversized packet is allowed, corrupted inputs could cause the reader to expect an impossibly large pocket.